### PR TITLE
Fix memset() to properly wipe client_data pointer

### DIFF
--- a/server.c
+++ b/server.c
@@ -57,7 +57,7 @@ int main(int argc, char* argv[])
             return 6;
         }
 
-        memset(client_data, 0, sizeof(client_data));
+        memset(client_data, 0, sizeof(client_data_t));
         unsigned int client_addr_len = sizeof(client_data->addr);
 
         if((client_data->socket_fd = accept(server_fd, &(client_data->addr), &client_addr_len)) == -1) {


### PR DESCRIPTION
Since client_data is a pointer, sizeof(client_data) will always be the word size of your architecture.
sizeof(client_data_t) represents the amount of space allocated by the previous malloc() call.